### PR TITLE
add sdv manager to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Below is a table with the currently available Galasa Managers as seen documented
 | Galasa Ecosystem | Other Managers | Alpha | 
 | Test Tool Managers || 
 | JMeter | JMeterManagerIVT ran locally during development | Beta |
+| SDV | - | Alpha |
 | Selenium | SeleniumManagerIVT ran locally during development | Beta |
 | Unix Managers || 
 | Linux | LinuxManagerIVT ran locally during development / Other Managers | Alpha |


### PR DESCRIPTION
I missed adding a new entry to the table in the readme.

I'm hoping to update the testing status once we've seen how well the IVT runs in the test ecosystem, hopefully a few changes will mean it will become part of the IVT test suite ran daily.